### PR TITLE
Adding `@discordjs/rest` in dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/Sayrix/ticket-bot#readme",
   "dependencies": {
+    "@discordjs/rest": "^1.5.0",
     "axios": "^1.1.3",
     "better-sqlite3": "^8.0.1",
     "discord-html-transcripts": "^3.1.2",


### PR DESCRIPTION
Because required in `deploy-commands.js`, Close #86