### PR TITLE
removed iconUrl by default to prevent bugs

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -4,16 +4,14 @@
       "title": "Öffne ein Ticket",
       "description": "Klicke auf den Button, um ein Ticket zu öffnen",
       "footer": {
-        "text": "is.gd/ticketbot",
-        "iconUrl": ""
+        "text": "is.gd/ticketbot"
       }
     },
     "ticketOpened": {
       "title": "Ticket CATEGORYNAME",
       "description": "Ein Teammitglied wird sich in Kürze um dich kümmern!",
       "footer": {
-        "text": "is.gd/ticketbot",
-        "iconUrl": ""
+        "text": "is.gd/ticketbot"
       }
     },
     "ticketClosed": {
@@ -24,8 +22,7 @@
       "title": "Ticket geschlossen",
       "description": "Das Ticket n°TICKETCOUNT wurde von CLOSERNAME mit folgendem Grund geschlossen: `REASON`\n\nHier findest du das Transkript: TRANSCRIPTURL",
       "footer": {
-        "text": "is.gd/ticketbot",
-        "iconUrl": ""
+        "text": "is.gd/ticketbot"
       }
     }
   },

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -4,16 +4,14 @@
       "title": "Ouvrir un ticket",
       "description": "Cliquez sur le bouton ci-dessous pour ouvrir un ticket.",
       "footer": {
-        "text": "is.gd/ticketbot",
-        "iconUrl": ""
+        "text": "is.gd/ticketbot"
       }
     },
     "ticketOpened": {
       "title": "Ticket CATEGORYNAME",
       "description": "Votre ticket a été ouvert. Un membre du staff va vous répondre dans les plus brefs délais.",
       "footer": {
-        "text": "is.gd/ticketbot",
-        "iconUrl": ""
+        "text": "is.gd/ticketbot"
       }
     },
     "ticketClosed": {
@@ -24,8 +22,7 @@
       "title": "Ticket fermé",
       "description": "Le ticket n°TICKETCOUNT a été fermé par CLOSERNAME avec comme raison: `REASON`\n\nVoice une transcript du ticket: TRANSCRIPTURL",
       "footer": {
-        "text": "is.gd/ticketbot",
-        "iconUrl": ""
+        "text": "is.gd/ticketbot"
       }
     }
   },

--- a/locales/main.json
+++ b/locales/main.json
@@ -4,16 +4,14 @@
       "title": "Open a ticket",
       "description": "Click on the button to start opening a ticket",
       "footer": {
-        "text": "is.gd/ticketbot",
-        "iconUrl": ""
+        "text": "is.gd/ticketbot"
       }
     },
     "ticketOpened": {
       "title": "Ticket CATEGORYNAME",
       "description": "A staff will reply you as soon as possible!",
       "footer": {
-        "text": "is.gd/ticketbot",
-        "iconUrl": ""
+        "text": "is.gd/ticketbot"
       }
     },
     "ticketClosed": {
@@ -24,8 +22,7 @@
       "title": "Ticket closed",
       "description": "The ticket n°TICKETCOUNT has been closed by CLOSERNAME with the following reason: `REASON`\n\nHere is the transcript of the ticket: TRANSCRIPTURL",
       "footer": {
-        "text": "is.gd/ticketbot",
-        "iconUrl": ""
+        "text": "is.gd/ticketbot"
       }
     }
   },


### PR DESCRIPTION
removed iconUrl by default to prevent bug
```
DiscordAPIError[50035]: Invalid Form Body
embeds[0].footer.icon_url[URL_TYPE_INVALID_SCHEME]: Scheme "" is not supported. Scheme must be one of ('http', 'https').
```