### PR TITLE
MySQL Table Name

### DIFF
--- a/config/config.example.jsonc
+++ b/config/config.example.jsonc
@@ -9,7 +9,8 @@
 		"host": "mysql.example.com", // The host of the MySQL database
 		"user": "mysql", // The user of the MySQL database
 		"password": "password", // The password of the MySQL database
-		"database": "ticketbot" // The name of the MySQL database
+		"database": "ticketbot", // The name of the MySQL database
+		"table": "json", // The name of the table where the tickets will be saved
 	},
 
 	"closeTicketCategoryId": "", // The id of the category where a closed ticket will be moved to. Leave blank to disable this feature

--- a/index.js
+++ b/index.js
@@ -74,7 +74,10 @@ if (client.config.mysql?.enabled) {
 
 		await mysql.connect();
 
-		db = new QuickDB({ driver: mysql });
+		db = new QuickDB({ 
+			driver: mysql,
+			table: client.config.mysql?.table ?? "json"
+		});
 		client.db = db;
 	})();
 } else {


### PR DESCRIPTION
I made some changes to the code that allows users to specify the name of the MySQL table in the config.jsonc file for quick.db. This is useful when you want to name the table something other than the default "json" string.

If the option is missing in the config.jsonc file, it will default to "json". I have tested this to ensure the functionality is working as expected. Could also be useful to write an updating system to automatically create the key in the jsonc file if it doesn't exist; however I didn't want to include that in the PR unless requested.

Please take a look at the changes and let me know your feedback.

Thanks!