### PR TITLE
fix: Dockerfile incorrectly ran the .sh file

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -23,4 +23,4 @@ COPY src ./src
 RUN npm run build
 
 # Start the server
-CMD ["./docker_run.sh"]
+ENTRYPOINT ["./docker_run.sh"]


### PR DESCRIPTION
Fixes #186

Note: This is actually my 2nd time writing docker related files and I've incorrectly use `CMD` instead of `ENTRYPOINT` to run the sh file.

Somehow my environment treats `CMD` as `ENTRYPOINT` (?!??!?) so I didn't get the error. This should fix the docker issue.