### PR TITLE
Fix JSON injection crash in close reason handling

### DIFF
--- a/src/utils/close.ts
+++ b/src/utils/close.ts
@@ -185,7 +185,7 @@ export async function close(
 				.setDisabled(deleteTicket)
 		);
 		const locale = client.locales;
-		// JSON.stringify().slice(1, -1) を使って安全にエスケープする（外側の引用符を除去しつつJSON特殊文字はエスケープ済み）
+		// Use JSON.stringify().slice(1, -1) to safely escape (strips outer quotes while keeping JSON special chars escaped)
 		const safeTicketCount = JSON.stringify(ticket.id.toString()).slice(1, -1);
 		const safeReason = JSON.stringify(
 			(ticket.closereason ?? client.locales.getSubValue("other", "noReasonGiven")).replace(/[\n\r]/g, "\\n")

--- a/src/utils/close.ts
+++ b/src/utils/close.ts
@@ -114,12 +114,12 @@ export async function close(
 			ViewChannel: false
 		})
 		.catch((e: unknown) => console.log(e));
-	invited.forEach(async (user) => {
-		(interaction.channel as TextChannel | null)?.permissionOverwrites
+	for (const user of invited) {
+		await (interaction.channel as TextChannel | null)?.permissionOverwrites
 			.edit(user, {
 				ViewChannel: false
 			});
-	});
+	}
 
 	interaction
 		.editReply({
@@ -185,14 +185,20 @@ export async function close(
 				.setDisabled(deleteTicket)
 		);
 		const locale = client.locales;
+		// JSON.stringify().slice(1, -1) を使って安全にエスケープする（外側の引用符を除去しつつJSON特殊文字はエスケープ済み）
+		const safeTicketCount = JSON.stringify(ticket.id.toString()).slice(1, -1);
+		const safeReason = JSON.stringify(
+			(ticket.closereason ?? client.locales.getSubValue("other", "noReasonGiven")).replace(/[\n\r]/g, "\\n")
+		).slice(1, -1);
+		const safeCloserName = JSON.stringify(interaction.user.tag).slice(1, -1);
 		interaction.channel
 			?.send({
 				embeds: [
 					JSON.parse(
 						JSON.stringify(locale.getSubRawValue("embeds", "ticketClosed"))
-							.replace("TICKETCOUNT", ticket.id.toString())
-							.replace("REASON", (ticket.closereason ?? client.locales.getSubValue("other", "noReasonGiven")).replace(/[\n\r]/g, "\\n"))
-							.replace("CLOSERNAME", interaction.user.tag)
+							.replace("TICKETCOUNT", safeTicketCount)
+							.replace("REASON", safeReason)
+							.replace("CLOSERNAME", safeCloserName)
 					)
 				],
 				components: [row]

--- a/src/utils/createTicket.ts
+++ b/src/utils/createTicket.ts
@@ -40,9 +40,9 @@ export const createTicket = async (
 		let allReasons = "";
 
 		if (typeof reasons === "object") {
-			reasons.forEach(async (r) => {
+			for (const [, r] of reasons) {
 				reason.push(r.value);
-			});
+			}
 			allReasons = reason.map((r, i) => `Question ${i + 1}: ${r}`).join(", ");
 		}
 		if (typeof reasons === "string") allReasons = reasons;


### PR DESCRIPTION
## Summary

- **Fix JSON injection in `close.ts`**: The `ticketClosed` embed is built by serializing to JSON, doing string replacements, then parsing back. User-provided `closereason` text containing `"`, `\`, or other JSON-special characters would break the JSON structure and cause `JSON.parse` to throw. Fixed by escaping all replacement values with `JSON.stringify(...).slice(1, -1)` before insertion, which preserves JSON-special character escaping while removing the surrounding quotes.
- **Fix `forEach(async ...)` anti-pattern**: Replaced `invited.forEach(async ...)` in `close.ts` with a `for...of` loop so permission overwrites are properly awaited. Also replaced `reasons.forEach(async ...)` in `createTicket.ts` with `for...of` (the callback there wasn't actually async-dependent, but the pattern is misleading and could hide errors).

## Test plan

- [ ] Set a ticket close reason containing `"`, `\`, and other JSON-special characters (e.g. `He said "hello" and typed C:\path\to\file`) — verify the bot does not crash and the embed displays correctly
- [ ] Set a close reason with newlines — verify they are handled as before
- [ ] Set a close reason with normal text — verify no regression
- [ ] Close a ticket with multiple invited users — verify all permission overwrites are applied sequentially without errors