### PR TITLE
fix(migration): restore v3 migration verification build step

### DIFF
--- a/scripts/verify-migrate-v3.mjs
+++ b/scripts/verify-migrate-v3.mjs
@@ -8,7 +8,7 @@ const rootDirectory = fileURLToPath(new URL("..", import.meta.url));
 const fixtureDirectory = path.join(rootDirectory, ".data");
 
 await mkdir(fixtureDirectory, { recursive: true });
-await run(process.execPath, [path.join(rootDirectory, "scripts", "build.mjs")]);
+await run(process.execPath, ["run", "build"]);
 
 const configModule = await import(pathToFileURL(path.join(rootDirectory, "dist", "config", "config.js")).href);
 const config = configModule.default;


### PR DESCRIPTION
replace the deleted `scripts/build.mjs` invocation and use the current package build command before running migration fixtures